### PR TITLE
Pass args to fast html

### DIFF
--- a/lib/floki/html_parser.ex
+++ b/lib/floki/html_parser.ex
@@ -21,15 +21,19 @@ defmodule Floki.HTMLParser do
 
   @default_parser Floki.HTMLParser.Mochiweb
 
-  @callback parse_document(binary()) :: {:ok, Floki.html_tree()} | {:error, String.t()}
-  @callback parse_fragment(binary()) :: {:ok, Floki.html_tree()} | {:error, String.t()}
+  @callback parse_document(binary(), list()) :: {:ok, Floki.html_tree()} | {:error, String.t()}
+  @callback parse_fragment(binary(), list()) :: {:ok, Floki.html_tree()} | {:error, String.t()}
 
   def parse_document(html, opts \\ []) do
-    parser(opts).parse_document(html)
+    parser_args = opts[:parser_args] || []
+
+    parser(opts).parse_document(html, parser_args)
   end
 
   def parse_fragment(html, opts \\ []) do
-    parser(opts).parse_fragment(html)
+    parser_args = opts[:parser_args] || []
+
+    parser(opts).parse_fragment(html, parser_args)
   end
 
   defp parser(opts) do

--- a/lib/floki/html_parser/fast_html.ex
+++ b/lib/floki/html_parser/fast_html.ex
@@ -3,13 +3,13 @@ defmodule Floki.HTMLParser.FastHtml do
   @moduledoc false
 
   @impl true
-  def parse_document(html) do
-    execute_with_module(fn module -> module.decode(html) end)
+  def parse_document(html, args) do
+    execute_with_module(fn module -> module.decode(html, args) end)
   end
 
   @impl true
-  def parse_fragment(html) do
-    execute_with_module(fn module -> module.decode_fragment(html) end)
+  def parse_fragment(html, args) do
+    execute_with_module(fn module -> module.decode_fragment(html, args) end)
   end
 
   defp execute_with_module(fun) do

--- a/lib/floki/html_parser/html5ever.ex
+++ b/lib/floki/html_parser/html5ever.ex
@@ -4,7 +4,7 @@ defmodule Floki.HTMLParser.Html5ever do
   @moduledoc false
 
   @impl true
-  def parse_document(html) do
+  def parse_document(html, _args) do
     case Code.ensure_loaded(Html5ever) do
       {:module, module} ->
         case module.parse(html) do
@@ -22,5 +22,5 @@ defmodule Floki.HTMLParser.Html5ever do
 
   # NOTE: html5ever does not implement parse_fragment yet.
   @impl true
-  def parse_fragment(html), do: parse_document(html)
+  def parse_fragment(html, args), do: parse_document(html, args)
 end

--- a/lib/floki/html_parser/mochiweb.ex
+++ b/lib/floki/html_parser/mochiweb.ex
@@ -5,7 +5,7 @@ defmodule Floki.HTMLParser.Mochiweb do
   @root_node "floki"
 
   @impl true
-  def parse_document(html) do
+  def parse_document(html, _args) do
     html = "<#{@root_node}>#{html}</#{@root_node}>"
     {@root_node, [], parsed} = :floki_mochi_html.parse(html)
 
@@ -14,5 +14,5 @@ defmodule Floki.HTMLParser.Mochiweb do
 
   # NOTE: mochi_html cannot make a distinction of a fragment and document.
   @impl true
-  def parse_fragment(html), do: parse_document(html)
+  def parse_fragment(html, args), do: parse_document(html, args)
 end


### PR DESCRIPTION
For testing partials with `fast_html`, we needed to pass arguments to its `parse` method. Since Floki did not support passing arguments to their HTML Parsers an option to pass arguments to the parser module was added.

Note that this only has effect on `fast_html`, since both `mochiweb` and `html5ever` do not support additional arguments.

This was needed because (for example) we had a partial for a table row. When testing this partial on it's own, the output would ignore the `tr` and `td` element, since it was 'invalid html' as the parent `table` element was missing.

This can be solved by passing a `context: "table"` to `fast_html`'s parse function, only Floki did not support passing along arguments.